### PR TITLE
Fix #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ class MyComponent extends React.Component {
 |---|---|---|
 |visible|boolean|Controls how panel should visible or not.
 |draggableRange|{top: number, bottom: number}|You can not drag panel out of this range. `top` default to visible height of device, `bottom` default to 0.
+|height|number|Control the height of panel. Default to height of window.
 |onDragStart|Function|Called when panel is about to start dragging.
 |onDrag|Function|Called when panel is dragging. Fires at most once per frame.
 |onDragEnd|Function|Called when you release your fingers.

--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -33,6 +33,7 @@ class SlidingUpPanel extends React.Component {
 
   static defaultProps = {
     visible: false,
+    height: visibleHeight,
     draggableRange: {top: visibleHeight, bottom: 0},
     onDrag: () => {},
     onDragStart: () => {},
@@ -227,7 +228,7 @@ class SlidingUpPanel extends React.Component {
     }
 
     const {top, bottom} = this.props.draggableRange
-    const height = this.props.height != null ? this.props.height : top - bottom
+    const height = this.props.height
 
     const translateY = this._translateYAnimation.interpolate({
       inputRange: [-top, -bottom],
@@ -241,7 +242,7 @@ class SlidingUpPanel extends React.Component {
       styles.animatedContainer,
       this.props.contentStyle,
       transform,
-      {height, top, bottom}
+      {height, top: visibleHeight, bottom: 0}
     ]
 
     return (

--- a/libs/layout.js
+++ b/libs/layout.js
@@ -1,6 +1,9 @@
-import {Platform, StatusBar, Dimensions} from 'react-native'
+var {Dimensions} = require('react-native')
 
-const statusBarHeight = Platform.OS === 'ios' ? 0 : StatusBar.currentHeight
-const {height: deviceHeight} = Dimensions.get('window')
+var layout = {
+  get visibleHeight() {
+    return Dimensions.get('window').height
+  }
+}
 
-export const visibleHeight = deviceHeight - statusBarHeight
+module.exports = layout

--- a/libs/styles.js
+++ b/libs/styles.js
@@ -1,5 +1,4 @@
 import {StyleSheet} from 'react-native'
-import {visibleHeight} from './layout'
 
 export default StyleSheet.create({
   container: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-sliding-up-panel",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Draggable sliding up panel implemented in React Native",
   "main": "SlidingUpPanel.js",
   "scripts": {


### PR DESCRIPTION
# Description:
- No need to calculate visible height due to the fact the it's already calculated when dimension changes, but rendering logic or styles that depend on these constants should try to call this function on every render.
- Can control the height of panel by passing `height` property.