### PR TITLE
Add the ability to cancel the flick in the onDragEnd event

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ class MyComponent extends React.Component {
 |height|number|Control the height of panel. Default to height of window.
 |onDragStart|Function|Called when panel is about to start dragging.
 |onDrag|Function|Called when panel is dragging. Fires at most once per frame.
-|onDragEnd|Function|Called when you release your fingers.
+|onDragEnd|Function|Called when you release your fingers. Return `true` to cancel the momentum event (use this to use `transitionTo` inside the onDragEnd function).
 |showBackdrop|boolean|Set to `false` to hide the backdrop behide panel. Default `true`.
 |allowDragging|boolean|Set to `false` to disable dragging. Touch outside panel or press back button (Android) to hide. Default `true`.
 |allowMomentum|boolean|If `false`, panel will not continue to move when you release your fingers. Default `true`.

--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -86,6 +86,11 @@ class SlidingUpPanel extends React.Component {
     if (nextProps.visible && !this.props.visible) {
       this.transitionTo(-this.props.draggableRange.top)
     }
+    
+    if(nextProps.draggableRange.top != this.props.draggableRange.top || nextProps.draggableRange.bottom != this.props.draggableRange.bottom) {
+      const {top, bottom} = nextProps.draggableRange
+      this._flick = new FlickAnimation(this._translateYAnimation, -top, -bottom)
+    }
   }
 
   componentDidUpdate() {

--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -134,9 +134,9 @@ class SlidingUpPanel extends React.Component {
     }
 
     this._translateYAnimation.flattenOffset()
-    this.props.onDragEnd(-this._animatedValueY)
+    const cancelFlick = this.props.onDragEnd(-this._animatedValueY)
 
-    if (!this.props.allowMomentum) {
+    if (!this.props.allowMomentum || cancelFlick) {
       return
     }
 


### PR DESCRIPTION
Fix issue #3. Simply return true from the onDragEnd event and TransitionTo will work. Even if allowMomentum is true.
````javascript
onDragEnd={(v) => {
    this._panel.transitionTo(this.state.draggableRange.snapPoint, null);
    return true;
}}
````