### PR TITLE
Top should be height of panel, not height of device window

### DIFF
--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -247,7 +247,7 @@ class SlidingUpPanel extends React.Component {
       styles.animatedContainer,
       this.props.contentStyle,
       transform,
-      {height, top: visibleHeight, bottom: 0}
+      {height, top: height, bottom: 0}
     ]
 
     return (


### PR DESCRIPTION
This will also fix issue #27, where you can set the height of the panel based on height of the container