### PR TITLE
Added draggable header

### DIFF
--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -33,7 +33,8 @@ class SlidingUpPanel extends React.Component {
     allowDragging: PropTypes.bool,
     showBackdrop: PropTypes.bool,
     contentStyle: PropTypes.any,
-    children: PropTypes.oneOfType([PropTypes.element, PropTypes.func])
+    children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+    renderDraggableHeader: PropTypes.func
   }
 
   static defaultProps = {
@@ -45,7 +46,8 @@ class SlidingUpPanel extends React.Component {
     onRequestClose: () => {},
     allowMomentum: true,
     allowDragging: true,
-    showBackdrop: true
+    showBackdrop: true,
+    renderDraggableHeader: null
   }
 
   constructor(props) {
@@ -295,6 +297,18 @@ class SlidingUpPanel extends React.Component {
           pointerEvents="box-none"
           style={animatedContainerStyles}>
           {this.props.children(this._panResponder.panHandlers)}
+        </Animated.View>
+      )
+    }
+
+    if (typeof this.props.renderDraggableHeader === 'function') {
+      return (
+        <Animated.View
+          key="content"
+          pointerEvents="box-none"
+          style={animatedContainerStyles}>
+          {this.props.renderDraggableHeader(this._panResponder.panHandlers)}
+          {this.props.children}
         </Animated.View>
       )
     }


### PR DESCRIPTION
Hi! 
I've tried the solution for scroll view inside sliding up view, and unfortunately, it didn't work for me.
I've created a method which allows you to declare custom render function for a header and will send panHandlers to it.

for using it you need to declare some rendering method like
`renderHeader = (panHendler) => {
    const { appointment, isOpen } = this.state;

    return (
      <View {...panHendler}/>
    );
  }`

and set up it to sliding up panel
`<SlidingUpPanel
    visible={this.props.visible}
    renderDraggableHeader={this.renderHeader}
/>`

If it would be useful for this module - I will create a demo and attach it to readme.