### PR TITLE
Switch exports to ES6 for Webpack compatibility

### DIFF
--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -28,6 +28,8 @@ const keyboardHideEvent = Platform.select({
   ios: 'keyboardWillHide'
 })
 
+const usableHeight = visibleHeight() - statusBarHeight()
+
 class SlidingUpPanel extends React.PureComponent {
   static propTypes = {
     height: PropTypes.number,
@@ -54,9 +56,9 @@ class SlidingUpPanel extends React.PureComponent {
   }
 
   static defaultProps = {
-    height: visibleHeight - statusBarHeight,
+    height: usableHeight,
     animatedValue: new Animated.Value(0),
-    draggableRange: {top: visibleHeight - statusBarHeight, bottom: 0},
+    draggableRange: {top: usableHeight, bottom: 0},
     snappingPoints: [],
     minimumVelocityThreshold: Constants.DEFAULT_MINIMUM_VELOCITY_THRESHOLD,
     minimumDistanceThreshold: Constants.DEFAULT_MINIMUM_DISTANCE_THRESHOLD,

--- a/libs/layout.js
+++ b/libs/layout.js
@@ -1,10 +1,9 @@
 import {StatusBar, Dimensions} from 'react-native'
 
-module.exports = {
-  get visibleHeight() {
-    return Dimensions.get('window').height
-  },
-  get statusBarHeight() {
-    return StatusBar.currentHeight || 0
-  }
+export function visibleHeight() {
+  return Dimensions.get('window').height
+}
+
+export function statusBarHeight() {
+  return StatusBar.currentHeight || 0
 }


### PR DESCRIPTION
With this change it is possible to use rn-sliding-up-panel on the web via React Native Web! It works well, so cool.