### PR TITLE
[TS] Show fn optional arg and export interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ import {
   GestureResponderHandlers
 } from 'react-native'
 
-interface Props {
+export interface SlidingUpPanelProps {
   height?: number
   animatedValue?: Animated.Value
   draggableRange?: {top: number; bottom: number}
@@ -32,13 +32,13 @@ interface Props {
     | ((dragHandlers: GestureResponderHandlers) => ReactElement)
 }
 
-interface AnimationConfig {
+export interface SlidingUpPanelAnimationConfig {
   toValue: number
   velocity: number
 }
 
-export default class SlidingUpPanel extends Component<Props> {
-  show: (value: number | AnimationConfig) => void
+export default class SlidingUpPanel extends Component<SlidingUpPanelProps> {
+  show: (value?: number | SlidingUpPanelAnimationConfig) => void
   hide: () => void
   scrollIntoView: (node: number) => void
 }


### PR DESCRIPTION
Just type fixes
* `show` funciton arg is said to be optional on readme
* Export interfaces to be able to create type safe objects:
```typescript
const unsafeProps = {
    friction: '10' // no problemo
}

const safeProps: SlidingUpPanelProps = {
    friction: '10' // error, must be number
}
```