### PR TITLE
Fix return type of `onBackButtonPress`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export interface SlidingUpPanelProps {
   minimumVelocityThreshold?: number
   minimumDistanceThreshold?: number
   avoidKeyboard?: boolean
-  onBackButtonPress?: () => void
+  onBackButtonPress?: () => boolean
   onDragStart?: (value: number, gestureState: PanResponderGestureState) => void
   onDragEnd?: (value: number, gestureState: PanResponderGestureState) => void
   onMomentumDragStart?: (value: number) => void


### PR DESCRIPTION
As explained [in the `BackHandler` docs](https://facebook.github.io/react-native/docs/backhandler), returning `true` is mandatory to avoid the default device behavior.

And as seen in this piece of code:

https://github.com/octopitus/rn-sliding-up-panel/blob/fb94487606374ac54580f6827be93a9774f5a165/SlidingUpPanel.js#L333-L335

The custom callback provided by the user must return a boolean too.