### PR TITLE
Use currentlyFocusInput instead of currentlyFocusedField

### DIFF
--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -312,10 +312,10 @@ class SlidingUpPanel extends React.PureComponent {
 
     this._storeKeyboardPosition(event.endCoordinates.screenY)
 
-    const node = TextInput.State.currentlyFocusedField()
+    const node = TextInput.State.currentlyFocusedInput()
 
     if (node != null) {
-      UIManager.viewIsDescendantOf(node, findNodeHandle(this._content), (isDescendant) => {
+      UIManager.viewIsDescendantOf(findNodeHandle(node), findNodeHandle(this._content), (isDescendant) => {
         isDescendant && this.scrollIntoView(node)
       });
     }


### PR DESCRIPTION
- Change soon-to-be deprecated currentlyFocusedField method to newly currentlyFocusedInput