### PR TITLE
Fix currentlyFocusedField deprecation error

### DIFF
--- a/SlidingUpPanel.js
+++ b/SlidingUpPanel.js
@@ -312,9 +312,9 @@ class SlidingUpPanel extends React.PureComponent {
 
     this._storeKeyboardPosition(event.endCoordinates.screenY)
 
-    const node = TextInput.State.currentlyFocusedField
-      ? TextInput.State.currentlyFocusedField()
-      : findNodeHandler(TextInput.State.currentlyFocusedInput());
+    const node = TextInput.State.currentlyFocusedInput
+      ? findNodeHandle(TextInput.State.currentlyFocusedInput())
+      : TextInput.State.currentlyFocusedField()
 
     if (node != null) {
       UIManager.viewIsDescendantOf(node, findNodeHandle(this._content), (isDescendant) => {


### PR DESCRIPTION
[#191](https://github.com/octopitus/rn-sliding-up-panel/issues/191) still seems to be an issue on v.2.4.4 with React Native 0.63.3

As it stands, currentlyFocusedField still exists, but is deprecated, so the warning will always show.
This PR checks if the new currentlyFocusedInput exists first, and falls back to the deprecated currentlyFocusedField if it does not.

Also `findNodeHandler` does not exist. Should be `findNodeHandle`.

<img width="443" alt="Screen Shot 2020-11-17 at 2 35 14 PM" src="https://user-images.githubusercontent.com/9326234/99453766-10d8c780-28eb-11eb-95b5-27bf1e22e091.png">
